### PR TITLE
Reduce blocking in main Naemon event loop

### DIFF
--- a/module/net.c
+++ b/module/net.c
@@ -568,7 +568,11 @@ int net_sendto(merlin_node *node, merlin_event *pkt)
 		return -1;
 	}
 
-	return node_send_event(node, pkt, 100);
+    /*
+     * Reduce the possibility of blocking the Naemon event loop.  Should
+     * we block for poll() at all?
+     */
+	return node_send_event(node, pkt, 10);
 }
 
 int net_sendto_many(merlin_node **ntable, uint num, merlin_event *pkt)

--- a/module/net.c
+++ b/module/net.c
@@ -568,11 +568,8 @@ int net_sendto(merlin_node *node, merlin_event *pkt)
 		return -1;
 	}
 
-    /*
-     * Reduce the possibility of blocking the Naemon event loop.  Should
-     * we block for poll() at all?
-     */
-	return node_send_event(node, pkt, 10);
+    /* Do not block in the Naemon event loop, retry on the next iteration. */
+	return node_send_event(node, pkt, 0);
 }
 
 int net_sendto_many(merlin_node **ntable, uint num, merlin_event *pkt)


### PR DESCRIPTION
With the Merlin network IO now being completely handled inside the
Naemon event loop, its possible under high numbers of checks and TCP
congestion / full buffers that we could end up poll()'ing and blocking
for 100ms for each check Naemon processes.  This starves the even loop
for resources, Naemon cannot process check results, and we are not
reading from the Merlin sockets.  This then cascades to peers as they
begin to block on a full TCP write buffer.

I've reduced the amount of time poll() will block for from 100ms to
10ms.  I wonder if we should not block at all in the event loop.