### PR TITLE
Fixing Multiline parsing of Query Handler output

### DIFF
--- a/apps/libexec/modules/nagios_qh.py
+++ b/apps/libexec/modules/nagios_qh.py
@@ -36,17 +36,8 @@ class nagios_qh:
 
 	def format(self, data, rowsep='\n', pairsep=';', kvsep='='):
 		"""Lazily format a response into a sequence of dicts"""
-		def todict(row):
-			return dict(x.split(kvsep, 1) for x in row.split(pairsep))
-		rest = ''
-		for block in data:
-			block = rest + block
-			rows = block.split(rowsep)
-			for row in rows[:-1]:
-				yield todict(row)
-			rest = rows[-1]
-		if rest:
-			yield todict(rest)
+                for row in filter(None, ''.join(data).split(rowsep)):
+			yield dict(x.split(kvsep, 1) for x in row.split(pairsep))
 
 	def get(self, query, rowsep='\n', pairsep=';', kvsep='='):
 		"""Ask a query to nagios' query handler socket, and return an object


### PR DESCRIPTION
The existing parsing of Query Handler output expects a single line to contain all the required data for it to be parsed correctly. We ran into some instances where the output was split across multiple lines (short reads?), causing parsing errors and or invalid output to checks such as the distribution check. This change first rejoins all Query Handler output and then splits on the rowsep.