### PR TITLE
module/hooks.c: Do not place MAGIC_NONET packets on the network

### DIFF
--- a/module/hooks.c
+++ b/module/hooks.c
@@ -107,6 +107,8 @@ static int send_generic(merlin_event *pkt, void *data)
 
 	if (!num_nodes)
 		return 0;
+	if (pkt->hdr.code == MAGIC_NONET)
+		return 0;
 
 	/*
 	 * The module can mark certain packets with a magic destination.


### PR DESCRIPTION
In commit

    8df9f641d8a73d87e955a174253b51703f721bdc
    MAGIC_NONET is meant for hdr->code

a conditional was removed from send_generic() that filtered packets
if hdr.selection == MAGIC_NONET.  This is clearly a bug as the
MAGIC_NONET value is meant for hdr.code to identify the packet, not
route it.  However, it has the same value as DEST_BROADCAST.

In most (all?) cases where we do not want to send a packet on the
network and hdr.code is set to MAGIC_NONET hdr.selection is left
unchanged from its initialized value of DEST_BROADCAST.  So, the removed
code was actually the final check for not sending MAGIC_NONET packets on
the network.  Since the above, I've had some really weird behavior with
merlin bouncing checks between nodes.

This patch adds back check for hdr.code == MAGIC_NONET so that
send_generic() honors the request not to place specific packets on the
network.