### PR TITLE
Monitor not reloaded on poller after "mon oconf fetch"

### DIFF
--- a/apps/libexec/oconf.fetch.sh.in
+++ b/apps/libexec/oconf.fetch.sh.in
@@ -61,17 +61,17 @@ for dest in $source; do
 if [ $dest ]; then
 	echo "Verify if a update is needed"
 	local_md5=$(cat /opt/monitor/etc/oconf/from-master.cfg | md5sum)
-	remote_md5=$(ssh $ssh_prefix @naemon_user@@$master cat @cachedir@/config/$fetch_name.cfg | md5sum)
+	remote_md5=$(ssh $ssh_prefix $master cat @cachedir@/config/$fetch_name.cfg | md5sum)
 
 	if [ "$local_md5" == "$remote_md5" ]; then
 		echo "Same md5sum, no need for a fetch, exiting"
 		exit
 	else
 		echo "Fetching config from $source"
-		echo "scp -p $scp_prefix @naemon_user@@$master:@cachedir@/config/$fetch_name.cfg /opt/monitor/etc/oconf/from-master.cfg"
-		scp -p $scp_prefix @naemon_user@@$master:@cachedir@/config/$fetch_name.cfg /opt/monitor/etc/oconf/from-master.cfg
+		echo "scp -p $scp_prefix $master:@cachedir@/config/$fetch_name.cfg /opt/monitor/etc/oconf/from-master.cfg"
+		scp -p $scp_prefix $master:@cachedir@/config/$fetch_name.cfg /opt/monitor/etc/oconf/from-master.cfg
 		echo "Restarting local instance"
-		mon restart
+		sudo mon restart
 	fi
 fi
 done


### PR DESCRIPTION
The mon oconf reload command is obsolete now.
However any user with sudo rights can copy config from master to poller
and can restart monitor.

MON-9232