### PR TITLE
oconf.py.in: only restart wanted nodes

### DIFF
--- a/apps/libexec/oconf.py.in
+++ b/apps/libexec/oconf.py.in
@@ -323,7 +323,7 @@ def cmd_push(args):
         exitval = 1
 
     if restart:
-        results = p.map(restart_node, mconf.configured_nodes.values())
+        results = p.map(restart_node, [node for (_, node) in wanted_nodes])
         for (res, out) in results:
             if out:
                 print out


### PR DESCRIPTION
A bug was created when parallelizing oconf push which would cause all nodes
to be restarted when only one was selected. This would all nodes to be
restarted n-1 times where n is the number of nodes in a cluster when pushing config
via merlin.

This is a quick fix which was discovered by Benjamin Ritcey in support ticket:
https://jira.op5.com/browse/SUPPORT-23248

Part of MON-10309

Signed-off-by: Robin Engström <robin.engstrom@op5.com>