### PR TITLE
Allow nodes with unresolvable DNS names

### DIFF
--- a/features/startup.feature
+++ b/features/startup.feature
@@ -1,0 +1,14 @@
+@config @daemons @merlin @queryhandler
+Feature: Startup of merlin and Naemon
+
+	Scenario: Naemon and Merlin should be able to start correct even if a Merlin
+		node has unresolvable DNS.
+
+		Given I have merlin configured for port 7000
+			| type | name    | address   | port |
+			| peer | my_peer | my_peer   | 4123 |
+
+		When I start naemon
+		And I wait for 1 second
+
+	Then my_peer should appear disconnected

--- a/features/step_definitions/service_startup.rb
+++ b/features/step_definitions/service_startup.rb
@@ -100,7 +100,9 @@ Given(/^I have merlin configured for port (\d+)$/) do |port, nodes|
     "
   nodes.hashes.each do |obj|
     configfile += sprintf "\n%s %s {\n", obj["type"], obj["name"]
-    configfile += "\taddress = 127.0.0.1\n" # There is no other way in tests
+    if !obj.include? 'address' then
+      configfile += "\taddress = 127.0.0.1\n" # There is no other way in tests
+    end
     obj.each do |key, value|
       if key != "type" and key != "name" and value != "ignore" then
         configfile += "\t#{key} = #{value}\n"

--- a/module/module.c
+++ b/module/module.c
@@ -1237,6 +1237,15 @@ static void connect_to_all(struct nm_event_execution_properties *evprop)
 		merlin_node *node = node_table[i];
 		if (node->state == STATE_CONNECTED || node->state == STATE_PENDING)
 			continue;
+
+		// check if the node has a valid IP address
+		// as we calloc the structure we can assume an un-resolved node
+		// will have an IP address = 0.
+		if (node->sain.sin_addr.s_addr == 0 ) {
+			resolve(node->name, &node->sain.sin_addr);
+		}
+
+		// connect to the node
 		net_try_connect(node);
 	}
 }

--- a/shared/node.c
+++ b/shared/node.c
@@ -287,7 +287,7 @@ linked_item *nodes_by_sel_name(const char *name)
  * Resolve an ip-address or hostname and convert it to a
  * machine-usable 32-bit representation
  */
-static int resolve(const char *cp, struct in_addr *inp)
+int resolve(const char *cp, struct in_addr *inp)
 {
 	struct addrinfo hints, *rp, *ai = NULL;
 	int result;
@@ -498,7 +498,7 @@ static void grok_node(struct cfg_comp *c, merlin_node *node)
 		address = node->name;
 
 	if (is_module && resolve(address, &node->sain.sin_addr) < 0)
-		cfg_error(c, address_var, "Unable to resolve '%s'\n", address);
+		cfg_warn(c, address_var, "Unable to resolve '%s'\n", address);
 
 	for (i = 0; i < c->nested; i++) {
 		struct cfg_comp *comp = c->nest[i];

--- a/shared/node.h
+++ b/shared/node.h
@@ -263,6 +263,7 @@ extern merlin_nodeinfo *self;
 #define online_pollers self->active_pollers
 #define online_nodes (online_masters + online_pollers + online_peers)
 
+extern int resolve(const char *cp, struct in_addr *inp);
 extern node_selection *node_selection_by_name(const char *name);
 extern char *get_sel_name(int index);
 extern int get_sel_id(const char *name);


### PR DESCRIPTION
This commit allows Merlin to function with nodes which DNS cannot be
resolved at startup. If no a given node could not be resolved at
startup merlin will try to resolve the nodes during the connect_to_all
function, which checks if disconnected nodes has become online.

Note that if the DNS changes, for a given node, then Merlin should be
restarted, as it will not attempt to resolve nodes that previously has
been resolved.

Signed-off-by: Jacob Hansen <jhansen@op5.com>