### PR TITLE
Passive poller: Correctly fetch object config.

### DIFF
--- a/apps/libexec/restart.sh.in
+++ b/apps/libexec/restart.sh.in
@@ -1,4 +1,14 @@
 #!/bin/sh
 
-mon stop
-mon start
+# Fix object config (does nothing if we're not a poller)
+mon oconf poller-fix
+
+# This script might be called from a Naemon worker process.
+# As a result, if we do a stop and start of naemon seperatly, it might happen 
+# that this script is killed before we issue the start command. Hence monitor
+# ends up in a stopped state. Calling restart fixes this issue.
+# However for some reason the service restart command does not exists until
+# we have called service stop of either merlin or naemon. Therefore we first
+# restart merlin with seperate commands, and thereafter restart naemon.
+/sbin/service merlind stop && /sbin/service merlind start
+/sbin/service naemon restart

--- a/features/config_sync_passive_poller.feature
+++ b/features/config_sync_passive_poller.feature
@@ -1,0 +1,59 @@
+@config @daemons @merlin @queryhandler
+Feature: Module should handle conf sync with poller
+	When a module realizes that another node has a config out of sync, the
+	module should start configuration sync, according to the config sync
+	directive in the merlin.conf
+
+	Background: I some default configuration in naemon
+		Given I have naemon host objects
+			| use          | host_name   | address   |
+			| default-host | something   | 127.0.0.1 |
+			| default-host | pollerthing | 127.0.0.1 |
+		And I have naemon hostgroup objects
+			| hostgroup_name | alias | members     |
+			| poller-group   | PG    | pollerthing |
+		And I have naemon service objects
+			| use             | host_name   | description |
+			| default-service | something   | PING        |
+			| default-service | pollerthing | PING        |
+		And I have merlin configured for port 7000
+			| type   | name   | port | fetch                  |
+			| master | master | 4001 | mon oconf fetch master |
+
+		When I start naemon
+		Then node ipc have info hash ipc_info_hash at 1000
+		And node ipc have expected hash ipc_expected_hash at 2000
+		And node master have info hash poller_info_hash at 3000
+		And node master have expected hash poller_expected_hash at 4000
+
+	Scenario: Same config and same timestamp should be accepted
+		Given master connect to merlin at port 7000 from port 11001
+		And master sends event CTRL_ACTIVE
+			| configured_masters |                    1 |
+			| last_cfg_change    |                 4000 |
+		When I wait for 1 second
+		Then master is connected to merlin
+		And master received event CTRL_ACTIVE
+			| last_cfg_change    |                 1000 |
+		And file config_sync.log does not match ^push
+		And file merlin.log does not match fetch triggered
+
+	Scenario: Different config and lower timestamp should be denied, poller should fetch if configured
+		Given master connect to merlin at port 7000 from port 11001
+		And master sends event CTRL_ACTIVE
+			| configured_masters |                    1 |
+			| last_cfg_change    |                 3900 |
+		When I wait for 1 second
+		Then master is not connected to merlin
+		And file merlin.log matches fetch triggered
+		And file config_sync.log does not match ^push
+
+	Scenario: Different config and higher timestamp should be denied, poller should fetch if configured
+		Given master connect to merlin at port 7000 from port 11001
+		And master sends event CTRL_ACTIVE
+			| configured_masters |                    1 |
+			| last_cfg_change    |                 4100 |
+		When I wait for 1 second
+		Then master is not connected to merlin
+		And file merlin.log matches fetch triggered
+		And file config_sync.log does not match ^push

--- a/features/step_definitions/service_startup.rb
+++ b/features/step_definitions/service_startup.rb
@@ -65,6 +65,7 @@ end
 Given(/^I have merlin configured for port (\d+)$/) do |port, nodes|
   push_cmd = "#!/bin/sh\necho \"push $@\" >> config_sync.log"
   fetch_cmd = "#!/bin/sh\necho \"fetch $@\" >> config_sync.log"
+
   configfile = "
     ipc_socket = test_ipc.sock;
 
@@ -104,8 +105,14 @@ Given(/^I have merlin configured for port (\d+)$/) do |port, nodes|
       configfile += "\taddress = 127.0.0.1\n" # There is no other way in tests
     end
     obj.each do |key, value|
-      if key != "type" and key != "name" and value != "ignore" then
+      if key != "type" and key != "name" and value != "ignore" and key != "fetch" then
         configfile += "\t#{key} = #{value}\n"
+      end
+      if key == "fetch" then
+        configfile += "\tobject_config {\n\t\tfetch_name = #{obj["name"]}\n\t\t#{key} = #{value}\n\t}\n"
+        # get rid of the general fetch cmd as otherwise it overrides the node
+        # specific one
+        configfile.sub! 'fetch = ./fetch_cmd;', ''
       end
     end
     configfile += "}\n"

--- a/shared/node.c
+++ b/shared/node.c
@@ -1227,6 +1227,24 @@ int node_oconf_cmp(const merlin_node *node, const merlin_nodeinfo *info)
 	/* if this is a master node, "any config" is as expected */
 	if (node->type == MODE_MASTER) {
 		ldebug("CSYNC: %s is a master in node_oconf_cmp", node->name);
+		/* If we should fetch config from the master node and the  config on the master
+		 * has changed, then we mark their config as newer, otherwise mark
+		 * everything as expected.
+		 *
+		 * Note that we check whether the the fetch.cmd contains 'mon oconf fetch'.
+		 * This is due to the fact that the fetch cmd might be used in other
+		 * capacities than to fetch configs from the master. This is for example
+		 * done during the tests.
+		 */
+		if (node->csync.fetch.cmd && strcmp(node->csync.fetch.cmd, "no") &&
+				strstr(node->csync.fetch.cmd, "mon oconf fetch") != NULL ) {
+			if (tdelta > 0) {
+				return 1;
+			} else if (tdelta < 0) {
+				return -1;
+			}
+		}
+
 		return 0;
 	}
 


### PR DESCRIPTION
This is the fix for MON-9774, that ensures that a passive poller with a specified mon oconf fetch command correctly fetches updates config from the master.

Signed-off-by: Jacob Hansen <jhansen@op5.com>