### PR TITLE
Tests,JSON: do not escape already escaped newlines

### DIFF
--- a/features/check_result_output.feature
+++ b/features/check_result_output.feature
@@ -49,5 +49,5 @@ Feature: Running active checks locally which returns multi-line output
 			| service_description      | PING                 |
 
 		Then plugin_output of service PING on host hostA should be Plugin output
-		And long_plugin_output of service PING on host hostA should be Long\nplugin\noutput
+		And long_plugin_output of service PING on host hostA should be Long\\nplugin\\noutput
 		And perf_data of service PING on host hostA should be Performance data

--- a/tests/cukemerlin/base/json.c
+++ b/tests/cukemerlin/base/json.c
@@ -1121,6 +1121,7 @@ void emit_string(SB *out, const char *str)
 	*b++ = '"';
 	while (*s != 0) {
 		unsigned char c = *s++;
+		unsigned char next = *s;
 
 		/* Encode the next character, and write it to b. */
 		switch (c) {
@@ -1130,7 +1131,8 @@ void emit_string(SB *out, const char *str)
 				break;
 			case '\\':
 				*b++ = '\\';
-				*b++ = '\\';
+				if (next != '\n')
+					*b++ = '\\';
 				break;
 			case '\b':
 				*b++ = '\\';


### PR DESCRIPTION
This commit ensures that the JSON library used for the cukemerlin tests
does not insert an extra escape if a newline is already escape in the
input.

This fix is needed for Merlin to pass tests with Naemon 1.0.7, which correctly escapes newlines in the long output of check results.

This fixes MON-11000

Signed-off-by: Jacob Hansen <jhansen@op5.com>