### PR TITLE
apps: correct path to oconf dir oconf push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ of month.
 
 ## [Unreleased]
 
+## [2021.10.2] - 2021-10-13
+### Fixed
+- Fixed an issue introduced in 2021.10.1 where `mon oconf push` would fail to
+  work when pushing to pollers on systems with non upstream naemon paths.
+
 ## [2021.10.1] - 2021-10-01
 ### Added
 - Community packages for CentOS/RHEL 7 & 8 are now generated with Open Suse

--- a/apps/libexec/oconf.py.in
+++ b/apps/libexec/oconf.py.in
@@ -478,7 +478,7 @@ def cmd_push(args):
                     wanted_nodes.remove((name, node))
                     continue
                 source = oconf_file
-                default_dest = '/etc/naemon/oconf/from-master.cfg'
+                default_dest = naemon_cfg_dir + '/oconf/from-master.cfg'
             else:
                 source = node.options.get('oconf_source', naemon_cfg_dir)
                 default_dest = naemon_cfg_dir_parent


### PR DESCRIPTION
2021.10.1 introduced an issue where `mon oconf push` would fail to work
when pushing to pollers on systems with non upstream naemon paths.