### PR TITLE
Fix EL9 Python 3.12 shebangs in merlin

### DIFF
--- a/apps/libexec/test.py
+++ b/apps/libexec/test.py
@@ -1586,7 +1586,7 @@ class fake_mesh:
 		ret = []
 		try:
 			self.dbc.execute("CREATE DATABASE %s" % inst.db_name)
-   			# Grant both localhost and wildcard hosts. On EL9/MariaDB, a
+			# Grant both localhost and wildcard hosts. On EL9/MariaDB, a
 			# pre-existing merlin@localhost account can take precedence over
 			# merlin@'%' and otherwise cause access denied for local connects.
 			self.dbc.execute("GRANT ALL ON %s.* TO merlin@'localhost' IDENTIFIED BY 'merlin'" % inst.db_name)

--- a/op5build/merlin.spec
+++ b/op5build/merlin.spec
@@ -487,7 +487,7 @@ rm -rf %buildroot
 
 %changelog
 * Mon Jul 13 2026 Jerick Macario <jmacario@itrsgroup.com>
-- Fix EL9 shebangs via py3_shebang_fix, sed, and ordered byte-compile.
+- EL9 platform support: Python 3.12 packaging, Naemon ABI, CI and test fixes
 * Wed Sep 24 2025 Jerick Macario <jmacario@itrsgroup.com>
 - Update Python to version 3.12
 - Temporary patch to move out python byte compile for apps module.

--- a/op5build/merlin.spec
+++ b/op5build/merlin.spec
@@ -248,11 +248,9 @@ cp -r apps/tests %buildroot/usr/share/merlin/app-tests
 mkdir -p %{buildroot}%{nacoma_hook_dir}
 sed -i 's#@@LIBEXECDIR@@#%_libdir/merlin#' op5build/nacoma_hook.py
 install -m 0755 op5build/nacoma_hook.py %{buildroot}%{nacoma_hook_dir}/merlin_hook.py
-%py_byte_compile %{__python3} %{buildroot}%{nacoma_hook_dir}/
-%py_byte_compile %{__python3} %{buildroot}%{mon_dir}/
 
-# brp-mangle-shebangs still runs after install; rewrites env python3 to 3.9.
-# Set shebangs to Python 3.12 before that step.
+# brp-mangle-shebangs still runs after install;
+# Set shebangs to Python 3.12, normalize, then byte-compile final sources.
 %py3_shebang_fix \
 	%{buildroot}%{mon_dir} \
 	%{buildroot}%{_bindir}/merlin_cluster_tools \
@@ -263,6 +261,8 @@ sed -i '1s/^#! \//#!\//' \
 	%{buildroot}%{nacoma_hook_dir}/merlin_hook.py
 find %{buildroot}%{mon_dir} -name '*.py' -exec grep -Il '^#! ' {} + 2>/dev/null \
 	| while read -r f; do sed -i '1s/^#! \//#!\//' "$f"; done
+%py_byte_compile %{__python3} %{buildroot}%{nacoma_hook_dir}/
+%py_byte_compile %{__python3} %{buildroot}%{mon_dir}/
 
 mkdir -p %buildroot%_sysconfdir/nrpe.d
 cp nrpe-merlin.cfg %buildroot%_sysconfdir/nrpe.d
@@ -486,6 +486,8 @@ fi
 rm -rf %buildroot
 
 %changelog
+* Mon Jul 13 2026 Jerick Macario <jmacario@itrsgroup.com>
+- Fix EL9 shebangs via py3_shebang_fix, sed, and ordered byte-compile.
 * Wed Sep 24 2025 Jerick Macario <jmacario@itrsgroup.com>
 - Update Python to version 3.12
 - Temporary patch to move out python byte compile for apps module.

--- a/op5build/merlin.spec
+++ b/op5build/merlin.spec
@@ -1,8 +1,9 @@
+# Drop automatic brp-python-bytecompile; we compile manually in install.
+%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 %define mod_path /opt/monitor/op5/merlin
 %define nacoma_hook_dir /opt/monitor/op5/nacoma/hooks/save
-%define python_ver 3.12
 %define mon_dir %{_libdir}/merlin/mon
-%global __python3 /usr/bin/python%{python_ver}
+%global python3_pkgversion 3.12
 
 
 # function service_control_function ("action", "service")
@@ -58,7 +59,7 @@ Requires: op5kad
 BuildRequires: mysql-devel
 %endif
 BuildRequires: op5-naemon-devel
-BuildRequires: python%{python_ver}-devel
+BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: gperf
 BuildRequires: check-devel
 BuildRequires: autoconf, automake, libtool
@@ -81,7 +82,7 @@ Requires: merlin-apps-slim >= %version
 Requires: glib2
 Requires: op5-monitor-user
 BuildRequires: op5-naemon-devel
-BuildRequires: python%{python_ver}-devel
+BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: gperf
 BuildRequires: check-devel
 BuildRequires: autoconf, automake, libtool
@@ -132,7 +133,7 @@ Requires: libdbi1
 Requires: python-mysql
 %else
 %if 0%{?rhel} >= 8
-Requires: python%{python_ver}-PyMySQL
+Requires: python%{python3_pkgversion}-PyMySQL
 %else
 Requires: MySQL-python
 %endif
@@ -142,7 +143,7 @@ Requires: unixcat
 # php-cli for mon node tree
 Requires: php-cli
 Requires: procps-ng
-Requires: python%{python_ver}-livestatus
+Requires: python%{python3_pkgversion}-livestatus
 Obsoletes: monitor-distributed
 Obsoletes: merlin-apps-slim
 
@@ -166,13 +167,13 @@ Group: op5/Monitor
 Requires: rsync
 Requires: openssh
 Requires: openssh-clients
-Requires: python%{python_ver}
+Requires: python%{python3_pkgversion}
 # php-cli for mon node tree
 Requires: php-cli
 Requires: procps-ng
 %if 0%{?rhel} >= 8
-Requires: python%{python_ver}-livestatus
-Requires: python%{python_ver}-cryptography
+Requires: python%{python3_pkgversion}-livestatus
+Requires: python%{python3_pkgversion}-cryptography
 %else
 Requires: python39-livestatus
 Requires: python36-docopt
@@ -205,7 +206,7 @@ Requires: systemd-udev
 Requires: libyaml
 Requires: mariadb-devel
 Requires: ruby-devel
-Requires: python%{python_ver}-pytest
+Requires: python%{python3_pkgversion}-pytest
 # Required development tools for building gems
 Requires: make automake gcc
 Requires: redhat-rpm-config
@@ -247,8 +248,15 @@ cp -r apps/tests %buildroot/usr/share/merlin/app-tests
 mkdir -p %{buildroot}%{nacoma_hook_dir}
 sed -i 's#@@LIBEXECDIR@@#%_libdir/merlin#' op5build/nacoma_hook.py
 install -m 0755 op5build/nacoma_hook.py %{buildroot}%{nacoma_hook_dir}/merlin_hook.py
-%py_byte_compile %{python3} %{buildroot}%{nacoma_hook_dir}/
-%py_byte_compile %{python3} %{buildroot}%{mon_dir}/
+%py_byte_compile %{__python3} %{buildroot}%{nacoma_hook_dir}/
+%py_byte_compile %{__python3} %{buildroot}%{mon_dir}/
+
+# brp-mangle-shebangs still runs after install; rewrites env python3 to 3.9.
+# Set shebangs to Python 3.12 before that step.
+%py3_shebang_fix -pni "%{__python3} %{py3_shbang_opts}" \
+	%{buildroot}%{mon_dir} \
+	%{buildroot}%{_bindir}/merlin_cluster_tools \
+	%{buildroot}%{nacoma_hook_dir}/merlin_hook.py
 
 mkdir -p %buildroot%_sysconfdir/nrpe.d
 cp nrpe-merlin.cfg %buildroot%_sysconfdir/nrpe.d
@@ -262,8 +270,8 @@ cp data/kad.conf %buildroot%_sysconfdir/op5kad/conf.d/merlin.kad
 %endif
 
 %check
-%{python3} tests/pyunit/test_log.py --verbose
-%{python3} tests/pyunit/test_oconf.py --verbose
+%{__python3} tests/pyunit/test_log.py --verbose
+%{__python3} tests/pyunit/test_oconf.py --verbose
 
 
 %post

--- a/op5build/merlin.spec
+++ b/op5build/merlin.spec
@@ -253,10 +253,16 @@ install -m 0755 op5build/nacoma_hook.py %{buildroot}%{nacoma_hook_dir}/merlin_ho
 
 # brp-mangle-shebangs still runs after install; rewrites env python3 to 3.9.
 # Set shebangs to Python 3.12 before that step.
-%py3_shebang_fix -pni "%{__python3} %{py3_shbang_opts}" \
+%py3_shebang_fix \
 	%{buildroot}%{mon_dir} \
 	%{buildroot}%{_bindir}/merlin_cluster_tools \
 	%{buildroot}%{nacoma_hook_dir}/merlin_hook.py
+# pathfix writes "#! /path" (space after #!); normalize to "#!/path"
+sed -i '1s/^#! \//#!\//' \
+	%{buildroot}%{_bindir}/merlin_cluster_tools \
+	%{buildroot}%{nacoma_hook_dir}/merlin_hook.py
+find %{buildroot}%{mon_dir} -name '*.py' -exec grep -Il '^#! ' {} + 2>/dev/null \
+	| while read -r f; do sed -i '1s/^#! \//#!\//' "$f"; done
 
 mkdir -p %buildroot%_sysconfdir/nrpe.d
 cp nrpe-merlin.cfg %buildroot%_sysconfdir/nrpe.d

--- a/op5build/merlin.spec
+++ b/op5build/merlin.spec
@@ -261,7 +261,7 @@ sed -i '1s/^#! \//#!\//' \
 	%{buildroot}%{nacoma_hook_dir}/merlin_hook.py
 find %{buildroot}%{mon_dir} -name '*.py' -exec grep -Il '^#! ' {} + 2>/dev/null \
 	| while read -r f; do sed -i '1s/^#! \//#!\//' "$f"; done
-%py_byte_compile %{__python3} %{buildroot}%{nacoma_hook_dir}/
+%py_byte_compile %{__python3} %{buildroot}%{nacoma_hook_dir}/merlin_hook.py
 %py_byte_compile %{__python3} %{buildroot}%{mon_dir}/
 
 mkdir -p %buildroot%_sysconfdir/nrpe.d


### PR DESCRIPTION
Use python3_pkgversion for EL9 Python macros.
Fix shebangs to 3.12 via py3_shebang_fix and sed.
Skip automatic brp-python-bytecompile.
This resolves MON-13872.

Signed-off-by: Jerick Macario <jmacario@itrsgroup.com>