### PR TITLE
Fix rrdcached self-check on EL9

### DIFF
--- a/apps/libexec/bash/inc.sh
+++ b/apps/libexec/bash/inc.sh
@@ -99,8 +99,18 @@ cmd_debug_section()
 # DESC: Basic check if this is a RHEL system.
 is_rhel()
 {
-  test -f /etc/rc.d/init.d/functions
-  return $?
+  # EL7/EL8 SysV marker (absent on EL9+).
+  [ -f /etc/rc.d/init.d/functions ] && return 0
+  # EL9+ (Rocky/RHEL/Alma) — detect via os-release.
+  [ -r /etc/os-release ] || return 1
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  case " ${ID} ${ID_LIKE} " in
+    *" rhel "*|*" centos "*|*" fedora "*|*" rocky "*|*" almalinux "*)
+      return 0
+      ;;
+  esac
+  return 1
 }
 
 # SNTX: is_sles

--- a/apps/libexec/syscheck/proc_rrdcached.sh
+++ b/apps/libexec/syscheck/proc_rrdcached.sh
@@ -1,7 +1,15 @@
 handler_desc='Checks the process state of the RRD caching daemon.'
 handler_exec()
 {
-  lockfile_rhel='/opt/monitor/var/rrdtool/rrdcached/rrdcached.pid'
+  local state_dir sock_path journal_dir perfdata_dir
+  local rrdcached_bin _pid
+
+  state_dir='/opt/monitor/var/rrdtool/rrdcached'
+  sock_path="${state_dir}/rrdcached.sock"
+  lockfile_rhel="${state_dir}/rrdcached.pid"
+  journal_dir="${state_dir}/journal"
+  perfdata_dir='/opt/monitor/op5/pnp/perfdata'
+  rrdcached_bin='/usr/bin/rrdcached'
   lockfile_sles="$lockfile_rhel"
   max='1'
 
@@ -14,6 +22,11 @@ handler_exec()
     # Trim trailing whitespace left by the final NUL.
     raw="${raw%"${raw##*[![:space:]]}"}"
     [ -n "$raw" ] || return 1
+    # Reject recycled PIDs that are not rrdcached.
+    case "$raw" in
+      "${rrdcached_bin} "*|"rrdcached "*) ;;
+      *) return 1 ;;
+    esac
     printf '%s' "$raw"
   }
 
@@ -29,7 +42,7 @@ handler_exec()
     [ "$_pid" != '0' ] && cmdline_rhel="$(_rrdcached_cmdline_from_pid "$_pid")"
   fi
   if [ -z "$cmdline_rhel" ]; then
-    cmdline_rhel='/usr/bin/rrdcached -g -l unix:/opt/monitor/var/rrdtool/rrdcached/rrdcached.sock -b /opt/monitor/op5/pnp/perfdata -B -R -p /opt/monitor/var/rrdtool/rrdcached/rrdcached.pid'
+    cmdline_rhel="${rrdcached_bin} -g -l unix:${sock_path} -b ${perfdata_dir} -B -R -p ${lockfile_rhel} -j ${journal_dir}"
   fi
   cmdline_sles="$cmdline_rhel"
 

--- a/apps/libexec/syscheck/proc_rrdcached.sh
+++ b/apps/libexec/syscheck/proc_rrdcached.sh
@@ -1,11 +1,37 @@
 handler_desc='Checks the process state of the RRD caching daemon.'
 handler_exec()
 {
-  cmdline_rhel='/usr/bin/rrdcached -p /opt/monitor/var/rrdtool/rrdcached/rrdcached.pid -m 0777 -l unix:/opt/monitor/var/rrdtool/rrdcached/rrdcached.sock -b /opt/monitor/var/rrdtool/rrdcached -P FLUSH,PENDING -z 1800 -w 1800 -s root -j /opt/monitor/var/rrdtool/rrdcached/spool -p /opt/monitor/var/rrdtool/rrdcached/rrdcached.pid'
-  cmdline_sles="$cmdline_rhel"
   lockfile_rhel='/opt/monitor/var/rrdtool/rrdcached/rrdcached.pid'
   lockfile_sles="$lockfile_rhel"
   max='1'
+
+  _rrdcached_cmdline_from_pid() {
+    local pid="$1" raw
+
+    [ -n "$pid" ] || return 1
+    [ -r "/proc/$pid/cmdline" ] || return 1
+    raw="$(tr '\0' ' ' < "/proc/$pid/cmdline")"
+    # Trim trailing whitespace left by the final NUL.
+    raw="${raw%"${raw##*[![:space:]]}"}"
+    [ -n "$raw" ] || return 1
+    printf '%s' "$raw"
+  }
+
+  # Match the live argv so flag changes (e.g. op5-rrdtool-config drop-in)
+  # do not break pgrep -fx in syscheck.proc.sh.
+  cmdline_rhel=
+  if [ -r "$lockfile_rhel" ]; then
+    read -r _pid < "$lockfile_rhel"
+    cmdline_rhel="$(_rrdcached_cmdline_from_pid "$_pid")"
+  fi
+  if [ -z "$cmdline_rhel" ]; then
+    _pid="$(systemctl show -p MainPID --value rrdcached.service 2>/dev/null)"
+    [ "$_pid" != '0' ] && cmdline_rhel="$(_rrdcached_cmdline_from_pid "$_pid")"
+  fi
+  if [ -z "$cmdline_rhel" ]; then
+    cmdline_rhel='/usr/bin/rrdcached -g -l unix:/opt/monitor/var/rrdtool/rrdcached/rrdcached.sock -b /opt/monitor/op5/pnp/perfdata -B -R -p /opt/monitor/var/rrdtool/rrdcached/rrdcached.pid'
+  fi
+  cmdline_sles="$cmdline_rhel"
 
   # continue processing by sourcing the generic proc script
   . "$base_dir/bash/syscheck.proc.sh"


### PR DESCRIPTION
Detect RHEL via os-release on EL9.
Match rrdcached argv from the live process.

This resolves MON-13889.

Signed-off-by: Jerick Macario <jmacario@itrsgroup.com>